### PR TITLE
Remove redundant check for WP_DEBUG being defined

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -40,7 +40,7 @@ add_action( 'wp_enqueue_scripts', function() {
 
 	$version = filemtime( get_stylesheet_directory() . '/style.dev.css' );
 
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	if ( true === WP_DEBUG ) {
 		wp_enqueue_style( 'mytheme-dev-style', get_template_directory_uri() . '/style.dev.css', array(), $version, 'screen' );
 	} else {
 		wp_enqueue_style( 'mytheme-style', get_stylesheet_uri() );


### PR DESCRIPTION
WordPress already defines it if it's not already defined. See https://github.com/WordPress/WordPress/blob/c2260dc85b279ac202a2fc4a6b42fb1211cd7b3a/wp-includes/default-constants.php#L59

Also, use strict type checking.
